### PR TITLE
fix for broken points() test

### DIFF
--- a/R/overrideGraphics.R
+++ b/R/overrideGraphics.R
@@ -8,7 +8,10 @@ overrideGraphics <- function(name, object, ...) {
     params <- list(...)
  
     if (!missing(object)) {
-      params <- append(object, params)
+      if (!is.null(names(object)))
+        params <- append(object, params)
+      else 
+        params <- append(list(object), params)
     }
     
     


### PR DESCRIPTION
fix for points

we had `list(object)` before, but that was breaking the `axis` and `legend` calls (or giving warnings)
