### PR TITLE
simplifying naming of windows

### DIFF
--- a/R/calc_views.R
+++ b/R/calc_views.R
@@ -67,7 +67,7 @@ group_views <- function(gsplot){
   views <- rep(list(view=c()),length(unique_sides))
   
   for (i in seq_len(length(unique_sides))){
-    views[[i]][['gs.config']][['side']] = unique_sides[[i]]
+    views[[i]][['window']][['side']] = unique_sides[[i]]
   }
   
   for (i in seq_len(length(gsplot))){
@@ -101,7 +101,7 @@ set_view_list <- function(views, var, na.action=NA, remove=TRUE){
     if (remove)
       views[[i]] <- lapply(views[[i]], function(x) remove_field(x, var))
     
-    views[[i]][['gs.config']][[var]] <- values
+    views[[i]][['window']][[var]] <- values
   }
   
   return(views)
@@ -126,15 +126,15 @@ set_view_lim <- function(views){
   for (i in names(data[[var]])){
     lim.name <- paste0(var,'lim')
     data.lim <- range(data[[var]][[i]], na.rm = T, na.action = NA)
-    usr.lim <- views[[as.numeric(i)]][['gs.config']][[lim.name]][1:2]
-    views[[as.numeric(i)]][['gs.config']][[lim.name]] <- ifelse(is.na(usr.lim), data.lim, usr.lim)
+    usr.lim <- views[[as.numeric(i)]][['window']][[lim.name]][1:2]
+    views[[as.numeric(i)]][['window']][[lim.name]] <- ifelse(is.na(usr.lim), data.lim, usr.lim)
   }
   var <- 'x'
   for (i in names(data[[var]])){
     lim.name <- paste0(var,'lim')
     data.lim <- range(data[[var]][[i]], na.rm = T, na.action = NA)
-    usr.lim <- views[[as.numeric(i)]][['gs.config']][[lim.name]][1:2]
-    views[[as.numeric(i)]][['gs.config']][[lim.name]] <- ifelse(is.na(usr.lim), data.lim, usr.lim)
+    usr.lim <- views[[as.numeric(i)]][['window']][[lim.name]][1:2]
+    views[[as.numeric(i)]][['window']][[lim.name]] <- ifelse(is.na(usr.lim), data.lim, usr.lim)
   }
   return(views)
 }

--- a/R/print.R
+++ b/R/print.R
@@ -32,22 +32,23 @@ print.gsplot <- function(x, ...){
   defaultPar <- par(no.readonly = TRUE)#, mar=legend_adjusted_margins(x))
   
   for (i in which(names(views) %in% 'view')){
-    view = views[[i]]
-    
+    plots = views[[i]]
+    plots[['window']] <- NULL
+    window = views[[i]][['window']]
     par(config("par")) 
     
-    plot.window(xlim = view$gs.config$xlim, ylim = view$gs.config$ylim, log = view$gs.config$log)
+    plot.window(xlim = window$xlim, ylim = window$ylim, log = window$log)
     
     # -- call functions -- 
-    to_gsplot(view, which(!names(view)  %in% 'gs.config'))
+    to_gsplot(plots)
 
-    if(!("axis" %in% names(view))){
-      axis(side=view$gs.config$side[1], config("axis"))
-      axis(side=view$gs.config$side[2], config("axis"))
+    if(!("axis" %in% names(plots))){ 
+      axis(side=window$side[1], config("axis"))
+      axis(side=window$side[2], config("axis"))
     }
 
-    mtext(text=view$gs.config$xlab, side=view$gs.config$side[1], line = 2)
-    mtext(text=view$gs.config$ylab, side=view$gs.config$side[2], line = 2)
+    mtext(text=window$xlab, side=window$side[1], line = 2)
+    mtext(text=window$ylab, side=window$side[2], line = 2)
     
     par(new=TRUE)
   }
@@ -59,8 +60,8 @@ print.gsplot <- function(x, ...){
   
 }
 
-to_gsplot <- function(x, which_i){
-  for (i in which_i){
+to_gsplot <- function(x){
+  for (i in seq_len(length(x))){
     do.call(names(x[i]),x[[i]])
   }
 }

--- a/R/print.R
+++ b/R/print.R
@@ -32,22 +32,23 @@ print.gsplot <- function(x, ...){
   defaultPar <- par(no.readonly = TRUE)#, mar=legend_adjusted_margins(x))
   
   for (i in which(names(views) %in% 'view')){
-    view = views[[i]]
-    
+    plots = views[[i]]
+    plots[['window']] <- NULL
+    window = views[[i]][['window']]
     par(config("par")) 
     
-    plot.window(xlim = view$gs.config$xlim, ylim = view$gs.config$ylim, log = view$gs.config$log)
+    plot.window(xlim = window$xlim, ylim = window$ylim, log = window$log)
     
     # -- call functions -- 
-    to_gsplot(view, which(!names(view)  %in% 'gs.config'))
+    to_gsplot(plots)
 
-    if(!("axis" %in% names(view))){
-      axis(side=view$gs.config$side[1], config("axis"))
-      axis(side=view$gs.config$side[2], config("axis"))
+    if(!("axis" %in% names(views[[i]]))){ 
+      axis(side=window$side[1], config("axis"))
+      axis(side=window$side[2], config("axis"))
     }
 
-    mtext(text=view$gs.config$xlab, side=view$gs.config$side[1], line = 2)
-    mtext(text=view$gs.config$ylab, side=view$gs.config$side[2], line = 2)
+    mtext(text=window$xlab, side=window$side[1], line = 2)
+    mtext(text=window$ylab, side=window$side[2], line = 2)
     
     par(new=TRUE)
   }
@@ -59,8 +60,8 @@ print.gsplot <- function(x, ...){
   
 }
 
-to_gsplot <- function(x, which_i){
-  for (i in which_i){
+to_gsplot <- function(x){
+  for (i in seq_len(length(x))){
     do.call(names(x[i]),x[[i]])
   }
 }


### PR DESCRIPTION
`windows` are what the view renders, vs `gs.config` are args that come from the function to set window properties. Separating these for simplicity and readability. 
