### PR TITLE
multiple callouts not broken

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gsplot
 Type: Package
 Title: Geological Survey Plotting
-Version: 0.2.2
+Version: 0.2.3
 Date: 2015-07-22
 Authors@R: c( person("Jordan", "Read", role = "aut",
     email = "jread@usgs.gov"),
@@ -13,7 +13,7 @@ Authors@R: c( person("Jordan", "Read", role = "aut",
     email = "thongsav@usgs.gov "),
     person("Megen","Hines", role="aut",
     email = "mhines@usgs.gov"),
-    person("Lindsey","Carr", role="aut",
+    person("Lindsay","Carr", role="aut",
     email = "lcarr@usgs.gov"))
 License: CC0
 Description: Workflow and plotting style defaults created for the U.S. Geological Survey.

--- a/R/callouts.R
+++ b/R/callouts.R
@@ -63,41 +63,56 @@ callouts.default <- function(x, y=NULL, labels=NA, length=0.1, angle='auto', ...
   yrange <- diff(y.usr)
   
   try.angle <- function() {
-    x1 = x + length * xrange * cos(2*pi*(angle/360));
-    y1 = y + length * yrange * sin(2*pi*(angle/360));
+    x1 = x[i] + length[i] * xrange * cos(2*pi*(angle.loop/360));
+    y1 = y[i] + length[i] * yrange * sin(2*pi*(angle.loop/360));
     return(c(x1,y1))
   }
   
-  if (angle=='auto') {
-    angle <- 30
+  num.callouts <- max(length(x), length(y)) #determine how many points are given for callouts
+  if (length(angle) < num.callouts) {angle <- rep(angle, num.callouts)} #duplicate angles if only one given
+  if (length(length) < num.callouts) {length <- rep(length, num.callouts)} #duplicate lengths if only one given
+  if (length(x[!is.na(x)])==1) {x <- rep(x[1], num.callouts)}  #duplicate x values if only one given
+  if (length(y[!is.na(y)])==1) {y <- rep(y[1], num.callouts)}  #duplicate y values if only one given
+  x1 <- c()
+  y1 <- c()
+  pos <- c()
+  
+  for (i in 1:num.callouts) {
+    
+    angle.loop <- angle[i]
+    
+    if (angle.loop=='auto') {
+      angle.loop <- 30
+      x.y <- try.angle()
+      
+      if(x.y[2] > y.usr[2]){
+        angle.loop <- 330
+        x.y <- try.angle()
+        if(x.y[1] > x.usr[2]){angle.loop <- 210}
+      }
+      
+      if(x.y[1] > x.usr[2]) {
+        angle.loop <- 210
+        x.y <- try.angle()
+        if(x.y[2] < y.usr[1]){angle.loop <- 150}
+      }
+    }
+    
+    stopifnot(angle.loop >= 0, angle.loop <= 360)
     x.y <- try.angle()
+    x1[i] <- x.y[1]
+    y1[i] <- x.y[2]
     
-    if(x.y[2] > y.usr[2]){
-      angle <- 330
-      x.y <- try.angle()
-      if(x.y[1] > x.usr[2]){angle <- 210}
+    if (angle.loop >= 315 | angle.loop <= 45){
+      pos[i] = 4
+    } else if (angle.loop > 45 & angle.loop <= 135) {
+      pos[i] = 3
+    } else if (angle.loop > 135 & angle.loop <= 225){
+      pos[i] = 2
+    } else {
+      pos[i] = 1
     }
     
-    if(x.y[1] > x.usr[2]) {
-      angle <- 210
-      x.y <- try.angle()
-      if(x.y[2] < y.usr[1]){angle <- 150}
-    }
-  }
-  
-  stopifnot(angle >= 0, angle <= 360)
-  x.y <- try.angle()
-  x1 <- x.y[1]
-  y1 <- x.y[2]
-  
-  if (angle >= 315 | angle <= 45){
-    pos = 4
-  } else if (angle > 45 & angle <= 135) {
-    pos = 3
-  } else if (angle > 135 & angle <= 225){
-    pos = 2
-  } else {
-    pos = 1
   }
   
   segments(x0=x, y0=y, x1=x1, y1=y1, ...)

--- a/R/callouts.R
+++ b/R/callouts.R
@@ -84,9 +84,13 @@ callouts.default <- function(x, y=NULL, labels=NA, length=0.1, angle='auto', ...
     good.y1 <- y1 >= y.usr[1] & y1 <= y.usr[2]
     good.x1 <- x1 >= x.usr[1] & x1 <= x.usr[2]
     good.pt <- good.y1 & good.x1
-    angle <- auto.angle[apply(good.pt, 1, function(z){
-      ifelse(!any(z), 1, min(which(z)))
-    })]
+    if (!is.null(dim(good.pt))){
+      angle <- auto.angle[apply(good.pt, 1, function(z){
+        ifelse(!any(z), 1, min(which(z)))
+      })]
+    } else { 
+      angle <- auto.angle[ifelse(!any(good.pt), 1, min(which(good.pt)))]
+    }
     x1 <- x + length * xrange * cos(2*pi*(angle/360))
     y1 <- y + length * yrange * sin(2*pi*(angle/360))
   }


### PR DESCRIPTION
Only way I could think to remedy the issue was by using a for loop. Using an apply function wasn't making sense to me, but others might have a better idea. Also, I had to add some initialization of objects before the loop in order for it to grab and store the correct values. 

PT brought up an issue with multiple callouts requested:

``` r
gs <- gsplot()  %>% 
    points(c(1,2), c(2,3))  %>% 
    callouts(c(1,2), c(2,3), labels=c("more", "stuff"))
gs
```

The if statements used for `angle=auto` did not understand how to handle multiple xy points. 
