### PR TITLE
legend fix - bg, lwd, and cex were not making it into the pts args

### DIFF
--- a/R/set_args.R
+++ b/R/set_args.R
@@ -81,13 +81,11 @@ set_legend_args <- function(object, fun.name, ..., legend.name) {
     paramsAll <- set_type_params(paramsAll, type.name, params.needed)
     if(type.name %in% c('p', 'lchsS')) {fun.name <- switch(type.name, p="points", lchsS="lines")}
   }
-  
-  usr.args <- paramsAll[which(names(paramsAll) %in% names(fun.default))]
-  
+ 
   if (fun.name == "points") {
     pt.names <- c("lwd","bg","cex")
-    names(usr.args) <- replace(names(usr.args), which(names(usr.args) %in% pt.names), 
-                                paste0("pt.", pt.names[which(pt.names %in% names(usr.args))]))
+    names(paramsAll) <- replace(names(paramsAll), which(names(paramsAll) %in% pt.names), 
+                                paste0("pt.", pt.names[which(pt.names %in% names(paramsAll))]))
     fun.specific <- list(border=quote(par("bg")),
                          pch=1,
                          pt.bg=quote(par("bg")),
@@ -100,12 +98,13 @@ set_legend_args <- function(object, fun.name, ..., legend.name) {
                          lwd=1)
     
   } else if (fun.name %in% c("polygon", "rect")) {
-    names(usr.args) <- replace(names(usr.args), which(names(usr.args)=="col"), "fill")
-    usr.args$lty <- NA #lty/lwd should always be NA for polygon & rectangles in the legend
-    usr.args$lwd <- NA  
+    names(paramsAll) <- replace(names(paramsAll), which(names(paramsAll)=="col"), "fill")
+    paramsAll$lty <- NA #lty/lwd should always be NA for polygon & rectangles in the legend
+    paramsAll$lwd <- NA  
     fun.specific <- list(border=par("fg"))
   }
   
+  usr.args <- paramsAll[which(names(paramsAll) %in% names(fun.default))]
   fun.all <- replace(fun.default, match(names(fun.specific), names(fun.default)), fun.specific)
   add.args <- fun.all[!names(fun.all) %in% names(usr.args)]
   fun.legend.args <- append(usr.args, add.args)  


### PR DESCRIPTION
This was because `usr.args <- paramsAll[which(names(paramsAll) %in% names(fun.default))]` coming before bg, lwd, and cex were renamed with `pt.` caused them to not be stored in usr.args (because bg, lwd, and cex are not in fun.default - only pt.bg, pt.lwd, and pt.cex are). 
