### PR TITLE
side can be specified for error_bar

### DIFF
--- a/R/error_bars.R
+++ b/R/error_bars.R
@@ -60,7 +60,7 @@ error_bar.gsplot <- function(object, x, y, y.high=0, y.low=0, x.high=0, x.low=0,
     y.error <- y[errorIndex]
     x.error <- x[errorIndex]
     object <- arrows(object, x0=x.error, y0=y.error, x1=x.error, y1=y.low.coord, 
-                     length=epsilon, angle=90, ..., legend.name=legend.name)
+                     length=epsilon, angle=90, ..., side=side, legend.name=legend.name)
   }
   
   if(!all(y.high == 0)){
@@ -70,7 +70,7 @@ error_bar.gsplot <- function(object, x, y, y.high=0, y.low=0, x.high=0, x.low=0,
     y.error <- y[errorIndex]
     x.error <- x[errorIndex]
     object <- arrows(object, x0=x.error, y0=y.error, x1=x.error, y1=y.high.coord, length=epsilon, 
-                     angle=90, ..., legend.name=check_legend_name(legend.name, y.low))
+                     angle=90, ..., side=side, legend.name=check_legend_name(legend.name, y.low))
   }
   
   if(!all(x.low == 0)){
@@ -80,7 +80,7 @@ error_bar.gsplot <- function(object, x, y, y.high=0, y.low=0, x.high=0, x.low=0,
     x.error <- x[errorIndex]
     y.error <- y[errorIndex]
     object <- arrows(object, x0=x.error, y0=y.error, x1=x.low.coord, y1=y.error, length=epsilon, 
-                     angle=90, ..., legend.name=check_legend_name(legend.name, c(y.low, y.high)))
+                     angle=90, ..., side=side, legend.name=check_legend_name(legend.name, c(y.low, y.high)))
   }
   
   if(!all(x.high == 0)){
@@ -90,7 +90,7 @@ error_bar.gsplot <- function(object, x, y, y.high=0, y.low=0, x.high=0, x.low=0,
     x.error <- x[errorIndex]
     y.error <- y[errorIndex]
     object <- arrows(object, x0=x.error, y0=y.error, x1=x.high.coord, y1=y.error, length=epsilon, 
-                     angle=90, ..., legend.name=check_legend_name(legend.name, c(y.low, y.high, x.low)))
+                     angle=90, ..., side=side, legend.name=check_legend_name(legend.name, c(y.low, y.high, x.low)))
   }
 
   return(object)


### PR DESCRIPTION
@ldecicco-USGS @jread-usgs @jiwalker-usgs did we not have error_bar accept a `side` argument on purpose? Or was it just overlooked or changed at some point and never reverted?
