### PR TITLE
Adding a persist parameter

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -31,6 +31,7 @@ loadConfig = function(filename) {
 #'
 #' @param type string of gsplot config object to retrieve
 #' @param ... additional configuration to override what is pulled from config
+#' @param persist logical of whether to persist overrides to config
 #'
 #' @examples
 #' config("par")
@@ -38,7 +39,7 @@ loadConfig = function(filename) {
 #' @importFrom graphics plot.xy
 #' @importFrom graphics par
 #' @export
-config <- function(type, ...){
+config <- function(type, ..., persist=FALSE){
   allowedTypes <- c("par","points","lines","axis","plot",
                     "abline","legend","title","text",
                     "mtext","grid","segments",
@@ -93,6 +94,14 @@ config <- function(type, ...){
   } else {
     globalConfig[names(list(...))] <- NULL
     globalConfig <- append(globalConfig, list(...))
+  }
+  
+  if (persist){
+    if (type == "par"){
+      gsconfig$options[names(globalConfig)] <- globalConfig 
+    } else {
+      gsconfig$options[[type]] <- globalConfig
+    }
   }
   
   return(globalConfig)

--- a/man/config.Rd
+++ b/man/config.Rd
@@ -4,12 +4,14 @@
 \alias{config}
 \title{Get configuration for gsplot}
 \usage{
-config(type, ...)
+config(type, ..., persist = FALSE)
 }
 \arguments{
 \item{type}{string of gsplot config object to retrieve}
 
 \item{...}{additional configuration to override what is pulled from config}
+
+\item{persist}{logical of whether to persist overrides to config}
 }
 \description{
 Gets config for gsplot, mostly used internally

--- a/tests/testthat/tests-config.R
+++ b/tests/testthat/tests-config.R
@@ -1,5 +1,9 @@
 context("config")
 
+cleanup <- function() {
+  loadConfig()
+}
+
 test_that("lists and named args are identical", {
   expect_equal(gsplot:::config("par",list("mar"=c(1,2,3,4)))$mar, c(1,2,3,4))
   expect_equal(gsplot:::config("par",mar=c(1,2,3,4))$mar, c(1,2,3,4))
@@ -7,4 +11,12 @@ test_that("lists and named args are identical", {
 
 test_that("empty sets on gsplot are ignored",{
   expect_is(gsplot:::config("par"), 'list')
+})
+
+test_that("persisting to config alters environment", {
+  gsplot:::config("par", tcl=0.5, persist=TRUE)
+  gsplot:::config("points", col="blue", persist=TRUE)
+  expect_equal(gsplot:::config("par")$tcl, 0.5)
+  expect_equal(gsplot:::config("points")$col, "blue")
+  cleanup()
 })


### PR DESCRIPTION
to set stuff in the config that will persist for the session.  Reloading config from disk will undo any persisted config.  I'm going to try to tackle #130 but thought this would be a good start.
