### PR TITLE
access user defined at - already NULL in the object if not user defined

### DIFF
--- a/R/grid.R
+++ b/R/grid.R
@@ -115,12 +115,7 @@ grid_axTicks <- function(object, side){
 #' @return a series of ticks as a vector, or NULL if they weren't specified
 #' @keywords internal
 axis_axTicks <- function(object, side){
-  i <- which(names(object) %in% 'axis')
-  defined.sides <- sapply(i, function(x) object[[x]][['arguments']][['side']])
-  usr.at <- NULL
-  if(side %in% defined.sides){
-    axes.index <- i[defined.sides == side]
-    usr.at <- object[axes.index][['axis']][['arguments']][['at']]
-  }
+  i <- grep(as.side_name(side), names(object))
+  usr.at <- object[[i]][['axis']][['at']]
   return(usr.at)
 }


### PR DESCRIPTION
axis_axTicks was not pulling out the correct side info from the gsplot object. Now `usr.at` gets correct info. No need to set `usr.at <- NULL` because at should be NULL in the object if it wasn't user specified. This fixes #393 
