### PR TITLE
indexing allowed for points and lines

### DIFF
--- a/R/function_args.R
+++ b/R/function_args.R
@@ -45,6 +45,13 @@ function_args <- function(package, name, object, ..., use.default=paste0(name,'.
     names(params)[which(names(params) == "")] <- arg.names[seq_len(sum(names(params) == ""))]
   }
   
+  if(name %in% c('points', 'lines')){
+    if(!is.null(params[['x']]) & is.null(params[['y']])){
+      xy_args <- list(x = seq_along(params[['x']]),
+                      y = params[['x']])
+      params <- append_replace(params, xy_args)
+    }
+  }
   
   # // re-order
   sort.i <- seq_len(length(params))

--- a/R/set_args.R
+++ b/R/set_args.R
@@ -15,7 +15,7 @@ set_args <- function(fun.name, ..., custom.config = FALSE, package='graphics'){
   user_args <- function_args(name=fun.name, package=package, ...)
   
   if(fun.name %in% c('points', 'lines')){
-    xy_args <- xy.coords(x = user_args$x, y = user_args$y)
+    xy_args <- xy.coords(x = user_args[['x']], y = user_args[['y']])
     user_args <- append_replace(user_args, xy_args)
   }
   

--- a/R/set_args.R
+++ b/R/set_args.R
@@ -14,6 +14,11 @@ set_args <- function(fun.name, ..., custom.config = FALSE, package='graphics'){
   config_args <- config(fun.name, custom.config = custom.config)
   user_args <- function_args(name=fun.name, package=package, ...)
   
+  if(fun.name %in% c('points', 'lines')){
+    xy_args <- xy.coords(x = user_args$x, y = user_args$y)
+    user_args <- append_replace(user_args, xy_args)
+  }
+  
   indicesToAdd <- !(names(config_args) %in% names(user_args))
   arguments <- append(user_args, config_args[indicesToAdd])
   return(arguments)

--- a/R/set_args.R
+++ b/R/set_args.R
@@ -14,14 +14,6 @@ set_args <- function(fun.name, ..., custom.config = FALSE, package='graphics'){
   config_args <- config(fun.name, custom.config = custom.config)
   user_args <- function_args(name=fun.name, package=package, ...)
   
-  if(fun.name %in% c('points', 'lines')){
-    if(!is.null(user_args[['x']]) & is.null(user_args[['y']])){
-      xy_args <- list(x = seq_along(user_args[['x']]),
-                      y = user_args[['x']])
-      user_args <- append_replace(user_args, xy_args)
-    }
-  }
-  
   indicesToAdd <- !(names(config_args) %in% names(user_args))
   arguments <- append(user_args, config_args[indicesToAdd])
   return(arguments)

--- a/R/set_args.R
+++ b/R/set_args.R
@@ -15,8 +15,11 @@ set_args <- function(fun.name, ..., custom.config = FALSE, package='graphics'){
   user_args <- function_args(name=fun.name, package=package, ...)
   
   if(fun.name %in% c('points', 'lines')){
-    xy_args <- xy.coords(x = user_args[['x']], y = user_args[['y']])
-    user_args <- append_replace(user_args, xy_args)
+    if(!is.null(user_args[['x']]) & is.null(user_args[['y']])){
+      xy_args <- list(x = seq_along(user_args[['x']]),
+                      y = user_args[['x']])
+      user_args <- append_replace(user_args, xy_args)
+    }
   }
   
   indicesToAdd <- !(names(config_args) %in% names(user_args))

--- a/tests/testthat/test-arguments.R
+++ b/tests/testthat/test-arguments.R
@@ -1,7 +1,7 @@
 context("lining up default arguments")
 test_that("setting params with other default works as expected",{
-  expect_equal(gsplot:::function_args("grDevices","points", 1:5, y = NULL, 'label', use.default='xy.coords'), 
-               list(x=1:5, y=NULL,xlab='label'))
+  expect_equal(gsplot:::function_args("grDevices","points", 5:10, y = NULL, 'label', use.default='xy.coords'), 
+               list(x=1:6, y=5:10,xlab='label'))
 })
 
 test_that("setting params with class match works as expected",{

--- a/tests/testthat/tests-points.R
+++ b/tests/testthat/tests-points.R
@@ -15,7 +15,7 @@ test_that("graphics examples work", {
 
 context("points arguments")
 test_that("setting params works as expected",{
-  expect_equal(gsplot:::function_args("graphics","points", 5, y = NULL), list(x=5, y=NULL))
+  expect_equal(gsplot:::function_args("graphics","points", 5, y = NULL), list(x=1, y=5))
   expect_equal(gsplot:::function_args("graphics","points", y=5, x=0), list(x=0, y=5))
 })
 

--- a/tests/testthat/tests-points.R
+++ b/tests/testthat/tests-points.R
@@ -58,3 +58,18 @@ test_that("points.gsplot accepts formulas",{
            
 })
 
+test_that("points works with indexing", {
+  
+  x <- 7:10
+  gs <- gsplot() %>%
+    points(x)
+  expect_equal(class(gs$view.1.2$points$y), "integer")
+  expect_equal(gs$view.1.2$points$x, seq_along(x))
+  
+
+  oct_dates <- seq(as.Date("2015-10-11"), as.Date("2015-10-15"), by="days")
+  gs_dates <- gsplot() %>%
+    points(oct_dates)
+  expect_equal(class(gs_dates$view.1.2$points$y), "Date")
+  expect_equal(gs_dates$view.1.2$points$x, seq_along(oct_dates))
+})


### PR DESCRIPTION
Does not label x axis as "Index" and y with range. Works for logged axes and keeps user-specified axis labels. Also works with dates and other classes. It also works for `lines`.

See #245 

Originally, I had implemented this using `xy.coords` since that is what `points.default` and `lines.default` call, but if coerces data into numeric. 

```r
gs <- gsplot()  %>%
    points(1:10, xlab="my points", log="y")
gs
```

![image](https://cloud.githubusercontent.com/assets/13220910/21570839/6304d0ea-ce8f-11e6-97b9-d5d814e374ce.png)
