### PR TITLE
Axis log wrong side --- FIX

### DIFF
--- a/R/modify_par.R
+++ b/R/modify_par.R
@@ -1,11 +1,10 @@
 user.par <- names(par(no.readonly=TRUE))
 
 global.only.par <- c("ask", "fig", "fin", "lheight", "mai", "mar", "mex", "mfcol", "mfrow", "mfg",
-                     "new", "oma", "omd", "omi", "pin", "plt", "ps", "pty", "usr", "xlog", "ylog",
-                     "ylbias")
+                     "new", "oma", "omd", "omi", "pin", "plt", "ps", "pty", "usr", "ylbias")
 
-side.par <- c('cex.axis', 'col.axis', 'cex.lab', 'col.lab', 'font.axis', 'mgp', 'xaxp', 'yaxp', 
-              'tck', 'tcl', 'las', 'fg', 'xaxt', 'yaxt', 'adj', 'yaxs', 'xaxs','font.lab', 'ann')
+side.par <- c('cex.axis', 'col.axis', 'cex.lab', 'col.lab', 'font.axis', 'mgp', 'xaxp', 'yaxp', 'tck', 
+              'tcl', 'las', 'fg', 'xaxt', 'yaxt', 'adj', 'yaxs', 'xaxs','font.lab', 'ann', "xlog", "ylog")
 
 view.par <- user.par[!(user.par %in% side.par) & !(user.par %in% global.only.par)]
 

--- a/R/pass_view_args.R
+++ b/R/pass_view_args.R
@@ -18,6 +18,6 @@ view <- function(object, ...) {
 #' @export
 view.gsplot <- function(object, ..., side=c(1,2)){
   fun.name <- NULL
-  object <- gather_function_info(object, fun.name, ..., legend.name=NULL, side=c(1,2))
+  object <- gather_function_info(object, fun.name, ..., legend.name=NULL, side=side)
   return(object)
 }

--- a/R/print.R
+++ b/R/print.R
@@ -68,19 +68,18 @@ print.gsplot <- function(x, ...){
   view.usr <- par('usr')
   
   for (side.name in side.names){
+    par(x[[side.name]]$par)
     side <- as.side(side.name)
-    old.par <- par(x[[side.name]]$par)
     set_frame(views, side)
     if(x[[side.name]][['axes']] | x[[side.name]][['usr.axes']]){
       draw_axis(x, side.name)
     }
-    
     if(par('ann')){
       mtext(text=label(views, side), 
             side=side, line = 2, 
             las=config("mtext", custom.config = x[["global"]][["config"]][["config.file"]])$las)
     }
-    par(old.par)
+    par(old.par[which(names(old.par) %in% side.par)])
   }
   
   par(usr = view.usr)

--- a/R/print.R
+++ b/R/print.R
@@ -48,6 +48,8 @@ print.gsplot <- function(x, ...){
   view.info <- view_info(views)
   side.names <- side_names(views)
   
+  old.par <- par(no.readonly=TRUE)
+  
   for (view.name in view_names(views)){
     par(x$global$par)
     x.side.name <- as.x_side_name(view.name)
@@ -60,8 +62,7 @@ print.gsplot <- function(x, ...){
     }
 
     print.view(views[[view.name]])
-    
-    par(new=TRUE)
+    par(old.par)
   }
   
   view.usr <- par('usr')

--- a/tests/testthat/test-pass_view_args.R
+++ b/tests/testthat/test-pass_view_args.R
@@ -15,3 +15,14 @@ test_that("frame.plot", {
   expect_false(gs$global$config$frame.plot)
   expect_false(gs$side.1$axes)
 })
+
+test_that("side", {
+  
+  gs <- gsplot() %>% points(1,2, side=3) %>% view(log='x')
+  expect_true(gs$side.1$log)
+  expect_false(gs$side.3$log)
+  
+  gs <- gsplot() %>% points(1,2) %>% view(side=3, log='x')
+  expect_true(gs$side.3$log)
+  expect_false(gs$side.1$log)
+})


### PR DESCRIPTION
Fixing #414 

Test out:

```r
# side 4 logged, side 2 not logged
gs <- gsplot() %>% 
  points(1:3, c(1,10,100)) %>% 
  points(3:5, c(10,100,1000), col="blue", side=4, log='y') %>% 
  axis(side=4)
gs

# side 3 logged, side 1 not logged
gs <- gsplot() %>% 
  points(c(1,10,100), 1:3, side=1) %>% 
  points(c(10,100,1000), 3:5, col="blue", side=3, log='x') %>% 
  axis(side=3)
gs

# side 3 logged, side 1 not logged
gs <- gsplot() %>% 
    points(c(1,10,100), 1:3, side=1) %>% 
    points(c(10,100,1000), 3:5, col="blue", side=3) %>% 
    axis(side=3) %>% 
    view(side=3, log='x')
gs

# side 1 logged, side 3 not logged
gs <- gsplot() %>% 
    points(c(1,10,100), 1:3, side=1) %>% 
    points(c(10,100,1000), 3:5, col="blue", side=3) %>% 
    axis(side=3) %>% 
    view(side=1, log='x')
gs
```