### PR TITLE
reset logs before adding default_view

### DIFF
--- a/R/print.R
+++ b/R/print.R
@@ -110,6 +110,17 @@ print.gsplot <- function(x, ...){
 
   if(!is.null(view.info)){
     default_view <- ifelse("view.1.2" %in% view.info$name, "view.1.2", view.info$name[1])
+    
+    # reset par logs before adding the default side
+    # otherwise, par is stuck on the last side added
+    for(side.name in as.side_name(default_view)){
+      if("x" == as.axis(side.name)){
+        par(xlog=views[[side.name]]$log)
+      } else {
+        par(ylog=views[[side.name]]$log)
+      }
+    }
+    
     set_frame(views, default_view)    
   }
   


### PR DESCRIPTION
Addressing error found by @zmoore-usgs when side 2 had negatives, but you were logging side 4. Side 4 was last to be added, so `par('ylog')` was TRUE when print got to `set_frame` for the default view and failed because of the negative values on side 2. Fix was to reset pars before adding default_view.

```r
plot2 <- gsplot() %>% 
  points(side=2, 1,-1) %>% 
  points(side=4, 100, 102) %>%
  view(side=4, log='y')
plot2

# this was the error that popped up, but doesn't now
Error in plot.window(xlim = xlim(object, as.x_side(view.name)), ylim = ylim(object,  : 
  Logarithmic axis must have positive limits
```
